### PR TITLE
solved issue with __plugname__ variable across modules

### DIFF
--- a/heap_viewer.py
+++ b/heap_viewer.py
@@ -19,40 +19,36 @@ idaapi.require('bingraph')
 
 #------------------------------------------------------------------------
 
-from plugin_gui import HeapPluginForm
-
-#------------------------------------------------------------------------
-__version__  = "0.1"
-__plugname__ = "HeapViewer"
+from plugin_gui import HeapPluginForm, PLUGNAME
 
 # -----------------------------------------------------------------------
 class HeapViewPlugin(idaapi.plugin_t):
     flags = 0
     comment = ""
     help = ""
-    wanted_name = __plugname__
+    wanted_name = PLUGNAME
     wanted_hotkey = "Ctrl-H"
 
     def init(self):
         self.icon_id = 0
-        return PLUGIN_KEEP
+        return idaapi.PLUGIN_KEEP
 
     def run(self, arg=0):
         try:
-            if "ELF" not in get_file_type_name():
-                raise Exception("Executable must be ELF format")
+            if "ELF" not in idaapi.get_file_type_name():
+                raise Exception("Executable must be ELF fomat")
 
-            if not is_debugger_on() or not idaapi.dbg_can_query():
+            if not idaapi.is_debugger_on() or not idaapi.dbg_can_query():
                 raise Exception("The debugger must be active and suspended before using this plugin")
 
             f = HeapPluginForm()
             f.Show()
 
         except Exception as e:
-            idaapi.warning("[%s] %s" % (__plugname__, e.message))
+            idaapi.warning("[%s] %s" % (PLUGNAME, e.message))
 
     def term(self):
-        idaapi.msg("[%s] terminated" % (__plugname__))
+        idaapi.msg("[%s] terminated" % (PLUGNAME))
 
 # -----------------------------------------------------------------------
 def PLUGIN_ENTRY():

--- a/heap_viewer/misc.py
+++ b/heap_viewer/misc.py
@@ -16,7 +16,8 @@ from ctypes import *
 from collections import OrderedDict
 
 # --------------------------------------------------------------------------
-__plugname__ = 'HeapViewer'
+PLUGVER  = "0.1"
+PLUGNAME = "HeapViewer"
 
 PLUGIN_DIR  = idadir(os.path.join("plugins", "heap_viewer"))
 FILES_DIR   = os.path.join(PLUGIN_DIR, "files")
@@ -48,7 +49,7 @@ class HeapConfig(object):
 
 # --------------------------------------------------------------------------
 def log(msg):
-    idaapi.msg("[%s] %s\n" % (__plugname__, msg))
+    idaapi.msg("[%s] %s\n" % (PLUGNAME, msg))
 
 # --------------------------------------------------------------------------
 def round_up(offset, alignment):

--- a/heap_viewer/plugin_gui.py
+++ b/heap_viewer/plugin_gui.py
@@ -145,7 +145,7 @@ class HeapPluginForm(PluginForm):
 
         try:
             current_libc_version = get_libc_version()
-            if self.config.libc_version == current_libc_version:
+            if self.config.libc_version == current_libc_version or current_libc_version == None:
                 self.heap = Heap(self.config)
                 self.btn_reload.setEnabled(True)
                 self.tabs.setTabEnabled(3, self.heap.tcache_enabled)
@@ -186,7 +186,7 @@ class HeapPluginForm(PluginForm):
         self.chunk_widget.show_chunk(address)
 
     def Show(self):
-        return PluginForm.Show(self, __plugname__, options = (
+        return PluginForm.Show(self, PLUGNAME, options = (
             PluginForm.FORM_TAB | PluginForm.FORM_CLOSE_LATER
         ))
     


### PR DESCRIPTION
Your plugin fails to load due to the __plugname__ variable used across modules. In python variables with two underscores at the beginning are private. I substituted it with PLUGNAME in the misc.py file.
In my test also the appcall to get_libc_version fails and i can't use the plugin.
I'm using ida 7 on wine, the debug server is on linux mint 18 libc 2.23.