### PR TITLE
solved issue when selecting chunk in main arena

### DIFF
--- a/heap_viewer/ui_widgets.py
+++ b/heap_viewer/ui_widgets.py
@@ -370,7 +370,7 @@ class ChunkWidget(CustomWidget):
     def show_chunk(self, expr):
         if type(expr) == str:
             self.t_chunk_addr.setText(expr)
-        elif type(expr) == int:
+        elif type(expr) == int or type(expr) == long:
             self.t_chunk_addr.setText("0x%x" % expr)
         self.view_chunk_on_click()
 


### PR DESCRIPTION
solved a gui issue, "Invalid Expression" exception in ChunkWidget was raised when the chunk address is a long instead of an int.